### PR TITLE
fixed msvc build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,11 @@ find_package(SDL2 REQUIRED)
 
 set(SOURCE_FILES src/main.c src/emu/nes_system.c)
 include_directories(src ${SDL2_INCLUDE_DIR})
-add_executable(nesm ${SOURCE_FILES})
+if (WIN32)
+    add_executable(nesm WIN32 ${SOURCE_FILES})
+else()
+    add_executable(nesm ${SOURCE_FILES})
+endif (WIN32)
 target_link_libraries(nesm ${SDL2_LIBRARY} ${EXTRA_LIBS})
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,7 @@ find_package(SDL2 REQUIRED)
 
 set(SOURCE_FILES src/main.c src/emu/nes_system.c)
 include_directories(src ${SDL2_INCLUDE_DIR})
-if (WIN32)
-    add_executable(nesm WIN32 ${SOURCE_FILES})
-else()
-    add_executable(nesm ${SOURCE_FILES})
-endif (WIN32)
+add_executable(nesm ${SOURCE_FILES})
 target_link_libraries(nesm ${SDL2_LIBRARY} ${EXTRA_LIBS})
 
 

--- a/src/emu/emu6502.h
+++ b/src/emu/emu6502.h
@@ -4,7 +4,6 @@
 #include "emu6502_opcodes.h"
 #include <stdint.h>
 #include <memory.h>
-#include <unistd.h>
 
 enum cpu_rw_mode
 {

--- a/src/emu/nes_rom.h
+++ b/src/emu/nes_rom.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <memory.h>
 
 #include "nes_cartridge.h"

--- a/src/main.c
+++ b/src/main.c
@@ -407,11 +407,3 @@ int main(int argc, char** argv)
     SDL_Quit();
     return 0;
 }
-
-
-#ifdef _WIN32
-int WinMain(int argc, char** argv)
-{
-    return main(argc, argv);
-}
-#endif

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ void ring_buf_write(ring_buf_t* ring, void* data, size_t data_size)
     else
     {
         memcpy(ring->buffer + ring->write, data, wrap_size);
-        memcpy(ring->buffer, data + wrap_size, data_size - wrap_size);
+        memcpy(ring->buffer, (char*)data + wrap_size, data_size - wrap_size);
     }
 
     ring->write = (ring->write + data_size) % ring->capacity;
@@ -79,7 +79,7 @@ size_t ring_buf_read(ring_buf_t* ring, void* dst, size_t dst_size)
     else
     {
         memcpy(dst, ring->buffer + ring->read, wrap_size);
-        memcpy(dst + wrap_size, ring->buffer, to_read - wrap_size);
+        memcpy((char*)dst + wrap_size, ring->buffer, to_read - wrap_size);
     }
 
     ring->read = (ring->read + to_read) % ring->capacity;
@@ -407,3 +407,11 @@ int main(int argc, char** argv)
     SDL_Quit();
     return 0;
 }
+
+
+#ifdef _WIN32
+int WinMain(int argc, char** argv)
+{
+    return main(argc, argv);
+}
+#endif


### PR DESCRIPTION
- on msvc, you can't add `void*` to int, because `void*` has no size. Have to cast to `char*` first.
- `unistd.h` doesn't seem to be used, and it's not available on windows.
- GUI applications on windows use `WinMain` instead of `main`, and need `/SUBSYSTEM:WINDOWS`, which the `WIN32` argument in `add_executable` will do in cmake.
- Windows uses wchar_t generally, so the rom loading logic has been slightly refactored around this. The file is opened in main now.
- SDL audio seems to be glitchy on windows unless `directsound` is used.